### PR TITLE
Fix a NameError in main()

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -272,7 +272,7 @@ class label_smoothing(nn.Module):
 if __name__ == '__main__':
     num_units = 512
     inputs = Variable(torch.randn((100, 10)))
-    outputs = position_encoding(num_units)(inputs)
+    outputs = positional_encoding(num_units)(inputs)
     outputs = multihead_attention(num_units)(outputs, outputs, outputs)
     outputs = feedforward(num_units)(outputs)
 


### PR DESCRIPTION
I fixed a NameError in main(). But still there exist other issues is your class "positional_encoding", round line 100 in the file modules.py . I am not quite sure that self._backend is inherited from nn.Module; and there is an AttributeError induced by this code: 

outputs = self._backend.Embedding.apply(
            position_ind, lookup_table, padding_idx, None, 2, False, False)

I will figure out further how to sort out the issue~